### PR TITLE
Open FastPathology demo section by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository includes the source code related to the preprint [_"Immunohistoc
 
 ## Using the trained model
 
-<details>
+<details open>
 <summary>
 
 ### With FastPathology</summary>


### PR DESCRIPTION
I missed this in the last PR, but saw it after the merge.